### PR TITLE
Add SetAdvertisement(u []UUID, m []byte)

### DIFF
--- a/server.go
+++ b/server.go
@@ -81,6 +81,13 @@ func (s *Server) Advertising() bool {
 	return s.adv.Serving()
 }
 
+// SetAdvertisement sets advertisement data to the specified
+// UUIDs and optional manufacture data. If the UUIDs is set to
+// nil, the UUIDs of added services will be used instead.
+func (s *Server) SetAdvertisement(u []UUID, m []byte) error {
+	return s.setAdvertisement(u, m)
+}
+
 // AdvertiseAndServe starts the server and advertises the UUIDs of its services.
 func (s *Server) AdvertiseAndServe() error {
 	if s.serving {

--- a/server_linux.go
+++ b/server_linux.go
@@ -57,6 +57,7 @@ func (s *Server) setAdvertisement(u []UUID, m []byte) error {
 		linux.AdvertisingIntervalMin(0x00f4),
 		linux.AdvertisingChannelMap(0x7),
 		linux.AdvertisingPacket(ad),
+		linux.ManufacturerData(m),
 		linux.ScanResponsePacket(nameScanResponsePacket(s.name)))
 	return s.adv.AdvertiseService()
 }


### PR DESCRIPTION
This allows users to set their advertisement with specific UUIDs and manufacturer data easily.

Otherwise, we need to unexport the helper functions, e.g. serviceAdvertisingPacket(), or have users to craft their own, if they don't like the default one.

p.s. If the code is okay, you can have another commit to polish the doc comments directly :-) 
