### PR TITLE
Suggested changes to improved error handling

### DIFF
--- a/linux/internal/socket/socket.go
+++ b/linux/internal/socket/socket.go
@@ -6,6 +6,7 @@
 package socket
 
 import (
+	"errors"
 	"syscall"
 	"time"
 	"unsafe"
@@ -28,6 +29,11 @@ const (
 	HCI_CHANNEL_USER    = 1
 	HCI_CHANNEL_MONITOR = 2
 	HCI_CHANNEL_CONTROL = 3
+)
+
+var (
+	ErrSocketOpenFailed  = errors.New("Unable to open bluetooth socket to device")
+	ErrSocketBindTimeout = errors.New("Timeout occured binding to bluetooth device")
 )
 
 type _Socklen uint32
@@ -70,7 +76,7 @@ func Socket(domain, typ, proto int) (int, error) {
 		}
 		time.Sleep(time.Second)
 	}
-	return 0, syscall.EBUSY
+	return 0, ErrSocketOpenFailed
 }
 
 func Bind(fd int, sa Sockaddr) (err error) {
@@ -84,7 +90,7 @@ func Bind(fd int, sa Sockaddr) (err error) {
 		}
 		time.Sleep(time.Second)
 	}
-	return syscall.EBUSY
+	return ErrSocketBindTimeout
 }
 
 func bind(s int, addr unsafe.Pointer, addrlen _Socklen) (err error) {

--- a/sample.go
+++ b/sample.go
@@ -14,6 +14,9 @@ import (
 )
 
 func main() {
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+
 	srv := gatt.NewServer(
 		gatt.Name("gophers"),
 		gatt.Connect(func(c gatt.Conn) { log.Println("Connect: ", c) }),

--- a/server_linux.go
+++ b/server_linux.go
@@ -70,7 +70,12 @@ func (s *Server) setManufacturerData(b []byte) {
 
 func (s *Server) start() error {
 	var logger *log.Logger
-	h := linux.NewHCI(logger, s.maxConnections)
+	h, err := linux.NewHCI(logger, s.maxConnections)
+
+	if err != nil {
+		return err
+	}
+
 	a := linux.NewAdvertiser(h.Cmd())
 	l := h.L2CAP()
 	l.Adv = a


### PR DESCRIPTION
Thanks for the new native bluetooth support in GATT, we are really looking forward to this feature.

I have been messing around with it to keep up with whats happening and ran into some issues, as identified, with older kernels.

This resulted in the code failing due to the errors being swallowed up and a nil `HCI` being returned. I was even more confused when I started getting `EBUSY` messages, rather than `EINVAL` which the `syscall` was returning.

To remedy this and try and make the API provide good feedback during operation I suggest passing these errors down the line where possible. In addition to this I have suggested some generalised errors when retrying fails socket open, or bind times out.

Note I know this is early days, just providing some suggestions which are more inline with what I see in the golang core.

cc @roylee17 