### PR TITLE
Added Indications Support for Linux implementation

### DIFF
--- a/peripheral.go
+++ b/peripheral.go
@@ -48,8 +48,11 @@ type Peripheral interface {
 	// WriteDescriptor writes the value of a characteristic descriptor.
 	WriteDescriptor(d *Descriptor, b []byte) error
 
-	// SetNotifyValue sets notifications or indications for the value of a specified characteristic.
+	// SetNotifyValue sets notifications for the value of a specified characteristic.
 	SetNotifyValue(c *Characteristic, f func(*Characteristic, []byte, error)) error
+
+	// SetIndicateValue sets indications for the value of a specified characteristic.
+	SetIndicateValue(c *Characteristic, f func(*Characteristic, []byte, error)) error
 
 	// ReadRSSI retrieves the current RSSI value for the remote peripheral.
 	ReadRSSI() int

--- a/peripheral_darwin.go
+++ b/peripheral_darwin.go
@@ -189,6 +189,12 @@ func (p *peripheral) SetNotifyValue(c *Characteristic, f func(*Characteristic, [
 	return nil
 }
 
+func (p *peripheral) SetIndicateValue(c *Characteristic,
+	f func(*Characteristic, []byte, error)) error {
+	// TODO: Implement set indications logic for darwin (https://github.com/paypal/gatt/issues/32)
+	return nil
+}
+
 func (p *peripheral) ReadRSSI() int {
 	rsp := p.sendReq(43, xpc.Dict{"kCBMsgArgDeviceUUID": p.id})
 	return rsp.MustGetInt("kCBMsgArgData")

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,10 @@ characteristics, you may need to reboot the other device to pick up the
 changes. This is a common source of confusion and apparent bugs. For an
 OS X central, see http://stackoverflow.com/questions/20553957.
 
+## Known Issues
+
+Currently OS X vesion  does not support subscribing to indications. 
+Please check [#32](https://github.com/paypal/gatt/issues/32) for the status of this issue.
 
 ## REFERENCES
 


### PR DESCRIPTION
Please review my changes and consider merging into your repo.
  
Added new method `Peripheral.SetIndicateValue` to subscribe for gatt indications similar to notifications. For Indications though we need to send acknowledgment which is done  by 
```
p.l2c.Write([]byte{attOpHandleCnf})
```

Current pr contains only linux implementation. Darwin version needs more investigation as seems less documented and uses some hard-coded values instead of constants.  