### PR TITLE
Increasing buffer size on responses channel

### DIFF
--- a/peripheral_linux.go
+++ b/peripheral_linux.go
@@ -329,7 +329,7 @@ func (p *peripheral) sendReq(op byte, b []byte) []byte {
 
 func (p *peripheral) loop() {
 	// Serialize the request.
-	rspc := make(chan []byte)
+	rspc := make(chan []byte, 2)
 
 	// Dequeue request loop
 	go func() {


### PR DESCRIPTION
Because of "Dequeue request loop" returning message into the channel (req.rspc <- r) this may deadlock if another response has been already pushed by other routine to the channel.  
It does locks consistently with devices that send a lot of notifications. 
Adding extra buffer in channel reserves space for that extra command to be returned.