### PR TITLE
WriteCharacteristics fix

### DIFF
--- a/peripheral_linux.go
+++ b/peripheral_linux.go
@@ -225,7 +225,7 @@ func (p *peripheral) WriteCharacteristic(c *Characteristic, value []byte, noRsp 
 	binary.LittleEndian.PutUint16(b[1:3], c.vh)
 	copy(b[3:], value)
 
-	if !noRsp {
+	if noRsp {
 		p.sendCmd(op, b)
 		return nil
 	}


### PR DESCRIPTION
When noResp is true it would send a write command, but expect a response; when noResp is false, it would send write request, and not expect a response, resulting in response being stuck in channel, blocking a Read loop, eventually putting the system into a deadlock on next WriteCharacteristic call.