### PR TITLE
runt packet fix (#37)

### DIFF
--- a/linux/hci.go
+++ b/linux/hci.go
@@ -375,7 +375,7 @@ func (h *HCI) handleL2CAP(b []byte) error {
 		return nil
 	}
 	if (len(a.b) < 4){	
-		log.Printf("l2conn: l2cap packet is too short/corrupt!")
+		log.Printf("l2conn: l2cap packet is too short/corrupt, length is %d",len(a.b))
 		return nil
 	}
 	cid := uint16(a.b[2]) | (uint16(a.b[3]) << 8)

--- a/linux/hci.go
+++ b/linux/hci.go
@@ -374,8 +374,8 @@ func (h *HCI) handleL2CAP(b []byte) error {
 		log.Printf("l2conn: got data for disconnected handle: 0x%04x", a.attr)
 		return nil
 	}
-	if (len(a.b) < 4){	
-		log.Printf("l2conn: l2cap packet is too short/corrupt, length is %d",len(a.b))
+	if len(a.b) < 4 {
+		log.Printf("l2conn: l2cap packet is too short/corrupt, length is %d", len(a.b))
 		return nil
 	}
 	cid := uint16(a.b[2]) | (uint16(a.b[3]) << 8)

--- a/linux/hci.go
+++ b/linux/hci.go
@@ -374,6 +374,10 @@ func (h *HCI) handleL2CAP(b []byte) error {
 		log.Printf("l2conn: got data for disconnected handle: 0x%04x", a.attr)
 		return nil
 	}
+	if (len(a.b) < 4){	
+		log.Printf("l2conn: l2cap packet is too short/corrupt!")
+		return nil
+	}
 	cid := uint16(a.b[2]) | (uint16(a.b[3]) << 8)
 	if cid == 5 {
 		c.handleSignal(a)


### PR DESCRIPTION
found via a nasty hw bug, the cid synthesis can cause a runtime error/array indexing error if the frame is too small.