### PR TITLE
add Getter/Setter of the service, characteristic, and descriptor.

### DIFF
--- a/common.go
+++ b/common.go
@@ -101,6 +101,21 @@ func (s *Service) Name() string {
 	return knownServices[s.uuid.String()].Name
 }
 
+// Handle returns the Handle of the service.
+func (s *Service) Handle() uint16 { return s.h }
+
+// EndHandle returns the End Handle of the service.
+func (s *Service) EndHandle() uint16 { return s.endh }
+
+// SetHandle sets the Handle of the service.
+func (s *Service) SetHandle(h uint16) { s.h = h }
+
+// SetEndHandle sets the End Handle of the service.
+func (s *Service) SetEndHandle(endh uint16) { s.endh = endh }
+
+// SetCharacteristics sets the Characteristics of the service.
+func (s *Service) SetCharacteristics(chars []*Characteristic) { s.chars = chars }
+
 // Characteristic returns the contained characteristic of this service.
 func (s *Service) Characteristics() []*Characteristic { return s.chars }
 
@@ -124,6 +139,46 @@ type Characteristic struct {
 	vh   uint16
 	endh uint16
 }
+
+// NewCharacteristic creates and returns a Characteristic.
+func NewCharacteristic(u UUID, s *Service, props Property, h uint16, vh uint16) *Characteristic {
+	c := &Characteristic{
+		uuid:  u,
+		svc:   s,
+		props: props,
+		h:     h,
+		vh:    vh,
+	}
+
+	return c
+}
+
+// Handle returns the Handle of the characteristic.
+func (c *Characteristic) Handle() uint16 { return c.h }
+
+// VHandle returns the Value Handle of the characteristic.
+func (c *Characteristic) VHandle() uint16 { return c.vh }
+
+// EndHandle returns the End Handle of the characteristic.
+func (c *Characteristic) EndHandle() uint16 { return c.endh }
+
+// Descriptor returns the Descriptor of the characteristic.
+func (c *Characteristic) Descriptor() *Descriptor { return c.cccd }
+
+// SetHandle sets the Handle of the characteristic.
+func (c *Characteristic) SetHandle(h uint16) { c.h = h }
+
+// SetVHandle sets the Value Handle of the characteristic.
+func (c *Characteristic) SetVHandle(vh uint16) { c.vh = vh }
+
+// SetEndHandle sets the End Handle of the characteristic.
+func (c *Characteristic) SetEndHandle(endh uint16) { c.endh = endh }
+
+// SetDescriptor sets the Descriptor of the characteristic.
+func (c *Characteristic) SetDescriptor(cccd *Descriptor) { c.cccd = cccd }
+
+// SetDescriptors sets the list of Descriptor of the characteristic.
+func (c *Characteristic) SetDescriptors(descs []*Descriptor) { c.descs = descs }
 
 // UUID returns the UUID of the characteristic.
 func (c *Characteristic) UUID() UUID {
@@ -265,6 +320,22 @@ type Descriptor struct {
 
 	rhandler ReadHandler
 	whandler WriteHandler
+}
+
+// Handle returns the Handle of the descriptor.
+func (d *Descriptor) Handle() uint16 { return d.h }
+
+// SetHandle sets the Handle of the descriptor.
+func (d *Descriptor) SetHandle(h uint16) { d.h = h }
+
+// NewDescriptor creates and returns a Descriptor.
+func NewDescriptor(u UUID, h uint16, char *Characteristic) *Descriptor {
+	cd := &Descriptor{
+		uuid: u,
+		h:    h,
+		char: char,
+	}
+	return cd
 }
 
 // UUID returns the UUID of the descriptor.


### PR DESCRIPTION
From previous [issue](https://github.com/paypal/gatt/issues/40), I found [noble](https://github.com/sandeepmistry/noble/) uses two tiny C programs to read/write HCI and L2CAP, and works on Intel Edison(kernel 3.10).
So that, I created [noblechild](https://github.com/shirou/noblechild) which provides almost same interface to paypal/gatt via noble's C programs.
Currently, noblechild can read/write attributes. But I have to make some changes to paypal/gatt.

This PR includes some setter/getter functions to use unexported variables in Server, Characteristic, and Descriptor. No other functions are changes.
Would you please merge this PR?

Thank you!
