### PR TITLE
Add Advertise(a *AdvPacket) to Device interface

### DIFF
--- a/device.go
+++ b/device.go
@@ -36,6 +36,9 @@ func (s State) String() string {
 type Device interface {
 	Init(stateChanged func(Device, State)) error
 
+	// Advertise advertise AdvPacket
+	Advertise(a *AdvPacket) error
+
 	// AdvertiseNameAndServices advertises device name, and specified service UUIDs.
 	// It tres to fit the UUIDs in the advertising packet as much as possible.
 	// If name doesn't fit in the advertising packet, it will be put in scan response.

--- a/device_darwin.go
+++ b/device_darwin.go
@@ -63,6 +63,11 @@ func (d *device) Init(f func(Device, State)) error {
 	return nil
 }
 
+func (d *device) Advertise(a *AdvPacket) error {
+	// TODO
+	return notImplemented
+}
+
 func (d *device) AdvertiseNameAndServices(name string, ss []UUID) error {
 	us := uuidSlice(ss)
 	rsp := d.sendReq(8, xpc.Dict{

--- a/device_linux.go
+++ b/device_linux.go
@@ -133,6 +133,19 @@ func (d *device) SetServices(s []*Service) error {
 	return nil
 }
 
+func (d *device) Advertise(a *AdvPacket) error {
+	d.advData = &cmd.LESetAdvertisingData{
+		AdvertisingDataLength: uint8(a.Len()),
+		AdvertisingData:       a.Bytes(),
+	}
+
+	if err := d.update(); err != nil {
+		return err
+	}
+
+	return d.hci.SetAdvertiseEnable(true)
+}
+
 func (d *device) AdvertiseNameAndServices(name string, uu []UUID) error {
 	a := &AdvPacket{}
 	a.AppendFlags(flagGeneralDiscoverable | flagLEOnly)
@@ -155,15 +168,8 @@ func (d *device) AdvertiseNameAndServices(name string, uu []UUID) error {
 			ScanResponseData:       a.Bytes(),
 		}
 	}
-	d.advData = &cmd.LESetAdvertisingData{
-		AdvertisingDataLength: uint8(a.Len()),
-		AdvertisingData:       a.Bytes(),
-	}
 
-	if err := d.update(); err != nil {
-		return err
-	}
-	return d.hci.SetAdvertiseEnable(true)
+	return d.Advertise(a)
 }
 
 func (d *device) AdvertiseIBeaconData(b []byte) error {
@@ -174,10 +180,8 @@ func (d *device) AdvertiseIBeaconData(b []byte) error {
 		AdvertisingDataLength: uint8(a.Len()),
 		AdvertisingData:       a.Bytes(),
 	}
-	if err := d.update(); err != nil {
-		return err
-	}
-	return d.hci.SetAdvertiseEnable(true)
+
+	return d.Advertise(a)
 }
 
 func (d *device) AdvertiseIBeacon(u UUID, major, minor uint16, pwr int8) error {


### PR DESCRIPTION
To support advertising custom formatted adv. packet.
It will make gatt support other beacons like Eddystone.

Currently only works in Linux.