### PR TITLE
darwin: implements device.Advertise.

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -64,8 +64,14 @@ func (d *device) Init(f func(Device, State)) error {
 }
 
 func (d *device) Advertise(a *AdvPacket) error {
-	// TODO
-	return notImplemented
+	rsp := d.sendReq(8, xpc.Dict{
+		"kCBAdvDataAppleMfgData": a.b, // not a.Bytes(). should be slice
+	})
+
+	if res := rsp.MustGetInt("kCBMsgArgResult"); res != 0 {
+		return errors.New("FIXME: Advertise error")
+	}
+	return nil
 }
 
 func (d *device) AdvertiseNameAndServices(name string, ss []UUID) error {


### PR DESCRIPTION
implements device.Advertise on darwin. I have confirmed it works using [go_eddystone](https://github.com/suapapa/go_eddystone) with little editing.

I read [bleno implementation](https://github.com/sandeepmistry/bleno/blob/master/lib/mac/bindings.js#L127) as a reference. It is just send a kCBAdvDataAppleMfgData Request.

I use AdvPacket.b directory, not `a.Bytes()`. Because at least my environment, a.Bytes() doesn't work because it is fixed length array.