### PR TITLE
add Stop to Device Interface so its possible to close Linux hci.

### DIFF
--- a/device.go
+++ b/device.go
@@ -72,6 +72,9 @@ type Device interface {
 	// StopScanning stops scanning.
 	StopScanning()
 
+	// Stop calls OS specific close calls
+	Stop() error
+
 	// Connect connects to a remote peripheral.
 	Connect(p Peripheral)
 

--- a/device_darwin.go
+++ b/device_darwin.go
@@ -142,6 +142,11 @@ func (d *device) StopAdvertising() error {
 	return nil
 }
 
+func (d *device) Stop() error {
+	// No Implementation
+
+}
+
 func (d *device) RemoveAllServices() error {
 	d.sendCmd(12, nil)
 	return nil


### PR DESCRIPTION
We ran into a bug where the kernel was never getting the HCI Disconnect which was causing an issue when we tried to open the connection again in certain situations. The only way that I can think to call this is to modify the interface to expose it. I've added an empty implementation for darwin also. 
