### PR TITLE
Add a validation for Advertising Data. Lengh should not be less than 1.

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -93,9 +93,10 @@ func (a *Advertisement) unmarshall(b []byte) error {
 			return errors.New("invalid advertise data")
 		}
 		l, t := b[0], b[1]
-		if len(b) < int(1+l) {
+		if int(l) < 1 || len(b) < int(1+l) {
 			return errors.New("invalid advertise data")
 		}
+
 		d := b[2 : 1+l]
 		switch t {
 		case typeFlags:


### PR DESCRIPTION
Without this validation, "panic: runtime error: slice bounds out of range" may happen. I added validation which ensure length should not be less than 1. 
