### PR TITLE
fix xpc_darwin.go avoid cgoCheckPointer

### DIFF
--- a/xpc/xpc_darwin.go
+++ b/xpc/xpc_darwin.go
@@ -289,7 +289,7 @@ func xpcToGo(v C.xpc_object_t) interface{} {
 	switch t {
 	case C.TYPE_ARRAY:
 		a := make(Array, C.int(C.xpc_array_get_count(v)))
-		C.XpcArrayApply(unsafe.Pointer(&a), v)
+		C.XpcArrayApply(C.uintptr_t(uintptr(unsafe.Pointer(&a))), v)
 		return a
 
 	case C.TYPE_DATA:
@@ -297,7 +297,7 @@ func xpcToGo(v C.xpc_object_t) interface{} {
 
 	case C.TYPE_DICT:
 		d := make(Dict)
-		C.XpcDictApply(unsafe.Pointer(&d), v)
+		C.XpcDictApply(C.uintptr_t(uintptr(unsafe.Pointer(&d))), v)
 		return d
 
 	case C.TYPE_INT64:

--- a/xpc/xpc_darwin_test.go
+++ b/xpc/xpc_darwin_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 )
 
-func CheckUUID(t *testing.T, v interface{}) UUID {
+func CheckUUID(t *testing.T, v interface{}) (uuid UUID) {
 	if uuid, ok := v.(UUID); ok {
 		return uuid
-	} else {
-		t.Errorf("not a UUID: %#v\n", v)
-		return uuid
 	}
+	t.Errorf("not a UUID: %#v\n", v)
+	return uuid
 }
 
 func TestConvertUUID(t *testing.T) {
@@ -23,7 +22,7 @@ func TestConvertUUID(t *testing.T) {
 
 	uuid2 := CheckUUID(t, v)
 
-	if uuid != uuid2 {
+	if uuid.String() != uuid2.String() {
 		t.Errorf("expected %#v got %#v\n", uuid, uuid2)
 	}
 }
@@ -36,7 +35,7 @@ func TestConvertSlice(t *testing.T) {
 
 	xpc_release(xv)
 
-	if arr2, ok := v.(array); !ok {
+	if arr2, ok := v.(Array); !ok {
 		t.Errorf("not an array: %#v\n", v)
 	} else if len(arr) != len(arr2) {
 		t.Errorf("expected %#v got %#v\n", arr, arr2)
@@ -57,7 +56,7 @@ func TestConvertSliceUUID(t *testing.T) {
 
 	xpc_release(xv)
 
-	if arr2, ok := v.(array); !ok {
+	if arr2, ok := v.(Array); !ok {
 		t.Errorf("not an array: %#v\n", v)
 	} else if len(arr) != len(arr2) {
 		t.Errorf("expected %#v got %#v\n", arr, arr2)
@@ -66,7 +65,7 @@ func TestConvertSliceUUID(t *testing.T) {
 			uuid1 := CheckUUID(t, arr[i])
 			uuid2 := CheckUUID(t, arr2[i])
 
-			if uuid1 != uuid2 {
+			if uuid1.String() != uuid2.String() {
 				t.Errorf("expected array[%d]: %#v got %#v\n", i, arr[i], arr2[i])
 			}
 		}
@@ -74,7 +73,7 @@ func TestConvertSliceUUID(t *testing.T) {
 }
 
 func TestConvertMap(t *testing.T) {
-	d := dict{
+	d := Dict{
 		"number": int64(42),
 		"text":   "hello gopher",
 		"uuid":   MakeUUID("aabbccddeeff00112233445566778899"),
@@ -85,7 +84,7 @@ func TestConvertMap(t *testing.T) {
 
 	xpc_release(xv)
 
-	if d2, ok := v.(dict); !ok {
+	if d2, ok := v.(Dict); !ok {
 		t.Errorf("not a map: %#v", v)
 	} else if len(d) != len(d2) {
 		t.Errorf("expected %#v got %#v\n", d, d2)
@@ -93,9 +92,22 @@ func TestConvertMap(t *testing.T) {
 		fail := false
 
 		for k, v := range d {
-			if v != d2[k] {
-				t.Logf("expected map[%s]: %#v got %#v\n", k, v, d2[k])
-				fail = true
+			switch got := d2[k].(type) {
+			case int64:
+				if v.(int64) != got {
+					t.Logf("expected map[%s]: %#v got %#v\n", k, v, got)
+					fail = true
+				}
+			case string:
+				if v.(string) != got {
+					t.Logf("expected map[%s]: %#v got %#v\n", k, v, got)
+					fail = true
+				}
+			case UUID:
+				if v.(UUID).String() != got.String() {
+					t.Logf("expected map[%s]: %#v got %#v\n", k, v, got)
+					fail = true
+				}
 			}
 		}
 

--- a/xpc/xpc_wrapper_darwin.c
+++ b/xpc/xpc_wrapper_darwin.c
@@ -61,16 +61,16 @@ void XpcSendMessage(xpc_connection_t conn, xpc_object_t message, bool release, b
     }
 }
 
-void XpcArrayApply(void *v, xpc_object_t arr) {
+void XpcArrayApply(uintptr_t v, xpc_object_t arr) {
   xpc_array_apply(arr, ^bool(size_t index, xpc_object_t value) {
-    arraySet(v, index, value);
+    arraySet((void *)v, index, value);
     return true;
   });
 }
 
-void XpcDictApply(void *v, xpc_object_t dict) {
+void XpcDictApply(uintptr_t v, xpc_object_t dict) {
   xpc_dictionary_apply(dict, ^bool(const char *key, xpc_object_t value) {
-    dictSet(v, (char *)key, value);
+    dictSet((void *)v, (char *)key, value);
     return true;
   });
 }

--- a/xpc/xpc_wrapper_darwin.h
+++ b/xpc/xpc_wrapper_darwin.h
@@ -20,8 +20,8 @@ extern xpc_object_t ERROR_CONNECTION_TERMINATED;
 
 extern xpc_connection_t XpcConnect(char *, void *);
 extern void XpcSendMessage(xpc_connection_t, xpc_object_t, bool, bool);
-extern void XpcArrayApply(void *, xpc_object_t);
-extern void XpcDictApply(void *, xpc_object_t);
+extern void XpcArrayApply(uintptr_t, xpc_object_t);
+extern void XpcDictApply(uintptr_t, xpc_object_t);
 extern void XpcUUIDGetBytes(void *, xpc_object_t);
 
 // the input type for xpc_uuid_create should be uuid_t but CGO instists on unsigned char *


### PR DESCRIPTION
change type
unsafe.Pointer => C.uintptr_t(uintptr(unsafe.Pointer))

ref https://github.com/golang/go/issues/12416

and fix test.
