### PR TITLE
Fix crash

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -93,7 +93,7 @@ func (a *Advertisement) unmarshall(b []byte) error {
 			return errors.New("invalid advertise data")
 		}
 		l, t := b[0], b[1]
-		if len(b) < int(1+l) {
+		if int(1+l) < 2 || len(b) < int(1+l) {
 			return errors.New("invalid advertise data")
 		}
 		d := b[2 : 1+l]


### PR DESCRIPTION
Considering the case where len(b) == 2
First check line 92: `len(b) < 2` will pass
Line 96: `len(b) < int(1+l)` can still pass if l == 1 or 0
Line 99: `b[2: 1+l]`
will crash with 2 possible signatures
if `l == 1`, index out of bound because right bound is 3 more than length
if `l == 0`, invalid slice index, right bound < left bound

The fix takes care of avoiding these 2 conditions checking the bounds
Note: result of line 99 can still be an empty slice

Signed-off-by: Flavio Crisciani <f.crisciani@gmail.com>