### PR TITLE
fix offset handling

### DIFF
--- a/central.go
+++ b/central.go
@@ -3,7 +3,6 @@ package gatt
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"sync"
 )
 
@@ -38,9 +37,6 @@ func newResponseWriter(c int) *responseWriter {
 }
 
 func (w *responseWriter) Write(b []byte) (int, error) {
-	if avail := w.capacity - w.buf.Len(); avail < len(b) {
-		return 0, fmt.Errorf("requested write %d bytes, %d available", len(b), avail)
-	}
 	return w.buf.Write(b)
 }
 

--- a/central_linux.go
+++ b/central_linux.go
@@ -275,7 +275,6 @@ func (c *central) handleRead(b []byte) []byte {
 	return w.Bytes()
 }
 
-// FIXME: check this, untested, might be broken
 func (c *central) handleReadBlob(b []byte) []byte {
 	h := binary.LittleEndian.Uint16(b)
 	offset := binary.LittleEndian.Uint16(b[2:])
@@ -303,6 +302,7 @@ func (c *central) handleReadBlob(b []byte) []byte {
 			d.rhandler.ServeRead(rsp, req)
 		}
 		v = rsp.bytes()
+		v = v[offset:]
 		offset = 0 // the server has already adjusted for the offset
 	}
 	w := newL2capWriter(c.mtu)


### PR DESCRIPTION
With this change you can send characteristic values ​​that are larger than the mtu.