### PR TITLE
Fix scanning ibeacon

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -2,7 +2,6 @@ package gatt
 
 import (
 	"errors"
-	"log"
 )
 
 // MaxEIRPacketLength is the maximum allowed AdvertisingPacket
@@ -131,7 +130,7 @@ func (a *Advertisement) unmarshall(b []byte) error {
 		// case typeServiceData32,
 		// case typeServiceData128:
 		default:
-			log.Printf("DATA: [ % X ]", d)
+			//log.Printf("DATA: [ % X ]", d)
 		}
 		b = b[1+l:]
 	}

--- a/adv.go
+++ b/adv.go
@@ -93,7 +93,7 @@ func (a *Advertisement) unmarshall(b []byte) error {
 			return errors.New("invalid advertise data")
 		}
 		l, t := b[0], b[1]
-		if len(b) < int(1+l) {
+		if len(b) < int(1+l) || l <= 1 {
 			return errors.New("invalid advertise data")
 		}
 		d := b[2 : 1+l]


### PR DESCRIPTION
occurring runtime error on scanning ibeacon.

```
panic: runtime error: slice bounds out of range

goroutine 2787 [running]:
github.com/paypal/gatt.(*Advertisement).unmarshall(0xc000200c80, 0xc000204b43, 0x1c, 0x1c, 0xfb00000000000001, 0x4)
        /home/hiro/go/src/github.com/paypal/gatt/adv.go:99 +0xa5d
github.com/paypal/gatt.(*device).Init.func3(0xc000208e60)
        /home/hiro/go/src/github.com/paypal/gatt/device_linux.go:97 +0x6d
github.com/paypal/gatt/linux.(*HCI).handleAdvertisement(0xc0000be000, 0xc0001d9113, 0xc, 0xc)
        /home/hiro/go/src/github.com/paypal/gatt/linux/hci.go:262 +0x2bc
created by github.com/paypal/gatt/linux.(*HCI).handleLEMeta
        /home/hiro/go/src/github.com/paypal/gatt/linux/hci.go:359 +0x1c6
```

and output many logs like this.

```
2019/05/14 06:50:50 DATA: [ 9F FE 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ]
2019/05/14 06:50:51 DATA: [ 26 FE 0A C9 5C ]
```