### PR TITLE
Avoid slice bounds out of range

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -96,6 +96,9 @@ func (a *Advertisement) unmarshall(b []byte) error {
 		if len(b) < int(1+l) {
 			return errors.New("invalid advertise data")
 		}
+		if l <= 2 {
+			return errors.New("invalid advertise data (l<=2)")
+		}
 		d := b[2 : 1+l]
 		switch t {
 		case typeFlags:


### PR DESCRIPTION
Fixed the following panic when scaning.

```
panic: runtime error: slice bounds out of range [2:1]

goroutine 18803 [running]:
github.com/paypal/gatt.(*Advertisement).unmarshall(0x2711ef0, 0x2761160, 0xe, 0xe, 0x115b94, 0x2492018)
	/home/pi/.go/src/github.com/paypal/gatt/adv.go:99 +0x8c4
github.com/paypal/gatt.(*device).Init.func3(0x24599e0)
	/home/pi/.go/src/github.com/paypal/gatt/device_linux.go:97 +0x50
github.com/paypal/gatt/linux.(*HCI).handleAdvertisement(0x248e040, 0x2796b93, 0xc, 0xc)
	/home/pi/.go/src/github.com/paypal/gatt/linux/hci.go:262 +0x214
created by github.com/paypal/gatt/linux.(*HCI).handleLEMeta
	/home/pi/.go/src/github.com/paypal/gatt/linux/hci.go:359 +0x114
```